### PR TITLE
FIX: fixed compiler extension import to most recent version

### DIFF
--- a/src/extension.onyx
+++ b/src/extension.onyx
@@ -1,4 +1,4 @@
-#load "core/onyx/compiler_extension"
+#load "core:onyx/compiler_extension"
 
 use onyx.compiler_extension {*}
 use core.conv


### PR DESCRIPTION
This is being done so that the Onyx MCP can add this repo as reference material for creating compiler extensions. With the PR it should now compile correctly.